### PR TITLE
Write output to stderr instead of stdout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+#### Changed
+
+- Progress bars are now written to standard error instead of standard output.
+  See https://github.com/fosskers/linya/pull/1.
+
 #### Fixed
 
 - Some documentation inaccuracies.

--- a/examples/cancel.rs
+++ b/examples/cancel.rs
@@ -9,7 +9,7 @@ use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 fn main() {
-    println!("Starting bars...");
+    eprintln!("Starting bars...");
 
     let progress = Arc::new(Mutex::new(Progress::new()));
 
@@ -32,5 +32,5 @@ fn main() {
         }
     });
 
-    println!("Complete!");
+    eprintln!("Complete!");
 }

--- a/examples/curl.rs
+++ b/examples/curl.rs
@@ -2,7 +2,7 @@ use curl::easy::Easy;
 use linya::{Bar, Progress};
 
 fn main() -> Result<(), curl::Error> {
-    println!("Starting tarball download...");
+    eprintln!("Starting tarball download...");
 
     let url = "";
     let mut progress = Progress::new();
@@ -28,6 +28,6 @@ fn main() -> Result<(), curl::Error> {
     // `write_function`.
     handle.perform()?;
 
-    println!("Complete!");
+    eprintln!("Complete!");
     Ok(())
 }

--- a/examples/multi.rs
+++ b/examples/multi.rs
@@ -7,7 +7,7 @@ use std::time::Duration;
 const BAR_MAX: usize = 1234;
 
 fn main() {
-    println!("Starting bars...");
+    eprintln!("Starting bars...");
 
     // `Progress` on its own can't be passed between threads, so we wrap it in
     // the usual sharing types.
@@ -37,5 +37,5 @@ fn main() {
         }
     });
 
-    println!("Complete!");
+    eprintln!("Complete!");
 }

--- a/examples/single.rs
+++ b/examples/single.rs
@@ -2,7 +2,7 @@ use linya::{Bar, Progress};
 use std::time::Duration;
 
 fn main() {
-    println!("Starting bar...");
+    eprintln!("Starting bar...");
 
     // `Progress` is not a bar, but a "bar coordinator".
     let mut progress = Progress::new();
@@ -18,5 +18,5 @@ fn main() {
         std::thread::sleep(Duration::from_millis(60));
     }
 
-    println!("Complete!");
+    eprintln!("Complete!");
 }


### PR DESCRIPTION
stderr is appropriate for dynamic output that's not intended to be machine-readable.

Even better on POSIX systems would be writing to `/dev/tty`, but I'm not sure what the cross-platform equivalent is there.