### PR TITLE
Avoid Overflows

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "linya"
 version = "0.2.1"
 authors = ["Colin Woodbury <colin@fosskers.ca>"]
-edition = "2018"
+edition = "2021"
 description = "Simple concurrent progress bars."
 homepage = "https://github.com/fosskers/linya"
 repository = "https://github.com/fosskers/linya"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -197,7 +197,7 @@ impl Progress {
                 let mut b = &mut self.bars[bar.0];
                 let w = (term_width / 2) - 7;
                 let (data, unit) = denomination(b.curr);
-                let diff = 100 * ((b.curr - b.prev) / b.total);
+                let diff = 100 * ((b.curr - b.prev) as u64 / (b.total as u64));
 
                 if b.cancelled {
                     let _ = write!(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -197,7 +197,7 @@ impl Progress {
                 let mut b = &mut self.bars[bar.0];
                 let w = (term_width / 2) - 7;
                 let (data, unit) = denomination(b.curr);
-                let diff = 100 * ((b.curr - b.prev) as u64 / (b.total as u64));
+                let diff = (100 * (b.curr - b.prev) as u64) / (b.total as u64);
 
                 if b.cancelled {
                     let _ = write!(
@@ -241,7 +241,7 @@ impl Progress {
                         unit,
                         "",
                         "",
-                        100 * (b.curr as u64) / (b.total as u64),
+                        (100 * (b.curr as u64)) / (b.total as u64),
                         l = term_width - w - 8 - 5,
                         f = f,
                         e = e

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -197,7 +197,7 @@ impl Progress {
                 let mut b = &mut self.bars[bar.0];
                 let w = (term_width / 2) - 7;
                 let (data, unit) = denomination(b.curr);
-                let diff = 100 * (b.curr - b.prev) / b.total;
+                let diff = 100 * ((b.curr - b.prev) / b.total);
 
                 if b.cancelled {
                     let _ = write!(
@@ -229,7 +229,7 @@ impl Progress {
                     let _ = self.out.flush();
                 } else if diff >= 1 {
                     b.prev = b.curr;
-                    let f = (w * b.curr / b.total).min(w - 1);
+                    let f = (w * (b.curr / b.total)).min(w - 1);
                     let e = (w - 1) - f;
 
                     let _ = write!(
@@ -241,7 +241,7 @@ impl Progress {
                         unit,
                         "",
                         "",
-                        100 * b.curr / b.total,
+                        100 * (b.curr / b.total),
                         l = term_width - w - 8 - 5,
                         f = f,
                         e = e

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -229,7 +229,7 @@ impl Progress {
                     let _ = self.out.flush();
                 } else if diff >= 1 {
                     b.prev = b.curr;
-                    let f = (w * (b.curr / b.total)).min(w - 1);
+                    let f = (((w as u64) * (b.curr as u64) / (b.total as u64)) as usize).min(w - 1);
                     let e = (w - 1) - f;
 
                     let _ = write!(
@@ -241,7 +241,7 @@ impl Progress {
                         unit,
                         "",
                         "",
-                        100 * (b.curr / b.total),
+                        100 * (b.curr as u64) / (b.total as u64),
                         l = term_width - w - 8 - 5,
                         f = f,
                         e = e


### PR DESCRIPTION
If the specified `total` we're incrementing toward was greater than `std::usize::MAX / 100`, a multiplication overflow would occur.