### PR TITLE
Added println function to Progress

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # `linya` Changelog
 
-## 0.3.0 (2022-03-08)
+## Unreleased
 
 #### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # `linya` Changelog
 
+## 0.3.0 (2022-03-08)
+
+#### Added
+
+- The `println` function for `Progress`.
+
 ## 0.2.2 (2022-02-21)
 
 #### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "linya"
-version = "0.2.2"
+version = "0.3.0"
 authors = ["Colin Woodbury <colin@fosskers.ca>"]
 edition = "2021"
 description = "Simple concurrent progress bars."

--- a/examples/multi.rs
+++ b/examples/multi.rs
@@ -1,6 +1,7 @@
 use linya::{Bar, Progress};
 use rand::Rng;
 use rayon::prelude::*;
+use std::fmt::Write;
 use std::sync::Mutex;
 use std::time::Duration;
 
@@ -35,10 +36,11 @@ fn main() {
 
             // We are half way done, write a message.
             if n == BAR_MAX / 2 {
-                progress
-                    .lock()
-                    .unwrap()
-                    .println(&format!("Half way done with #{}!", i));
+                let _ = writeln!(
+                    progress.lock().unwrap().stderr(),
+                    "Half way done with #{}!",
+                    i
+                );
             }
 
             std::thread::sleep(Duration::from_millis(wait));

--- a/examples/multi.rs
+++ b/examples/multi.rs
@@ -16,14 +16,14 @@ fn main() {
     // `for_each_with` and similar Rayon functions let us pass some `Clone`able
     // value to each concurrent operation. In this case, it's our Mutex-wrapped
     // progress bar coordinator.
-    (0..10).into_par_iter().for_each(|n| {
+    (0..10).into_par_iter().for_each(|i| {
         // Create a new bar handle. This itself is not a progress bar type as
         // found in similar libraries! Notice below that the increment/draw
         // calls are done on the parent `Progress` type, not this `Bar`.
         let bar: Bar = progress
             .lock()
             .unwrap()
-            .bar(BAR_MAX, format!("Downloading #{}", n));
+            .bar(BAR_MAX, format!("Downloading #{}", i));
 
         // Determine how fast our thread progresses.
         let wait = rand::thread_rng().gen_range(1..=10);
@@ -32,6 +32,14 @@ fn main() {
             // Only draws the line of the specified `Bar` without wasting
             // resources on the others.
             progress.lock().unwrap().set_and_draw(&bar, n);
+
+            // We are half way done, write a message.
+            if n == BAR_MAX / 2 {
+                progress
+                    .lock()
+                    .unwrap()
+                    .println(&format!("Half way done with #{}!", i));
+            }
 
             std::thread::sleep(Duration::from_millis(wait));
         }

--- a/examples/multi.rs
+++ b/examples/multi.rs
@@ -1,7 +1,6 @@
 use linya::{Bar, Progress};
 use rand::Rng;
 use rayon::prelude::*;
-use std::fmt::Write;
 use std::sync::Mutex;
 use std::time::Duration;
 

--- a/examples/multi.rs
+++ b/examples/multi.rs
@@ -34,15 +34,6 @@ fn main() {
             // resources on the others.
             progress.lock().unwrap().set_and_draw(&bar, n);
 
-            // We are half way done, write a message.
-            if n == BAR_MAX / 2 {
-                let _ = writeln!(
-                    progress.lock().unwrap().stderr(),
-                    "Half way done with #{}!",
-                    i
-                );
-            }
-
             std::thread::sleep(Duration::from_millis(wait));
         }
     });

--- a/examples/println.rs
+++ b/examples/println.rs
@@ -1,0 +1,74 @@
+use linya::{Bar, Progress};
+use rand::Rng;
+use std::fmt::Write;
+use std::sync::{Arc, Mutex};
+use std::thread;
+use std::time::Duration;
+
+const NUM_IMAGES: usize = 124;
+
+fn main() {
+    println!("Starting bars...");
+
+    // `Progress` on its own can't be passed between threads, so we wrap it in
+    // the usual sharing types.
+    let progress = Arc::new(Mutex::new(Progress::new()));
+
+    // We move `progress` into the `downl_thread` so we'll create another
+    // reference using `Arc::clone`.
+    let progress2 = progress.clone();
+
+    let downl_thread = thread::spawn(move || {
+        let bar: Bar = progress
+            .lock()
+            .unwrap()
+            .bar(NUM_IMAGES, "Downloading Images");
+
+        for i in 0..NUM_IMAGES {
+            std::thread::sleep(Duration::from_millis(10));
+
+            // Simulate our download failing
+            if rand::thread_rng().gen_ratio(1, 20) {
+                // Here we grab a handle to the part of stderr above the
+                // progress bars and write to it.
+                writeln!(
+                    progress.lock().unwrap().stderr(),
+                    "Image #{:03}: Downloading failed.",
+                    i
+                )
+                .unwrap();
+            }
+
+            progress.lock().unwrap().inc_and_draw(&bar, 1);
+        }
+    });
+
+    let process_thread = thread::spawn(move || {
+        let bar: Bar = progress2
+            .lock()
+            .unwrap()
+            .bar(NUM_IMAGES, "Post-processing Images");
+
+        for i in 0..NUM_IMAGES {
+            std::thread::sleep(Duration::from_millis(17));
+
+            // Simulate our resizing failing
+            // because we expected a square image.
+            if rand::thread_rng().gen_ratio(1, 25) {
+                writeln!(
+                    progress2.lock().unwrap().stderr(),
+                    "Image #{:03}: Not square.",
+                    i
+                )
+                .unwrap();
+            }
+
+            progress2.lock().unwrap().inc_and_draw(&bar, 1);
+        }
+    });
+
+    downl_thread.join().unwrap();
+    process_thread.join().unwrap();
+
+    println!("Complete!");
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -311,7 +311,7 @@ impl Progress {
     /// ```
     pub fn stderr(&mut self) -> impl fmt::Write + '_ {
         // Move to first line of the progress bars, erase the complete line and print the message.
-        let _ = write!(self.out, "\x1B[{}A\x1B[2K\r", self.bars.len()).map_err(|_e| fmt::Error);
+        let _ = write!(self.out, "\x1B[{}A\x1B[2K\r", self.bars.len()).map_err(|_| fmt::Error);
         WriteHandle { prog: self }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -334,8 +334,21 @@ impl<'a> fmt::Write for WriteHandle<'a> {
 
 impl<'a> Drop for WriteHandle<'a> {
     fn drop(&mut self) {
+        // Determine first bar that fits on screen.
+        let start = self
+            .prog
+            .size
+            .map(|(_w, h)| {
+                if self.prog.bars.len() >= h {
+                    self.prog.bars.len() - (h - 1)
+                } else {
+                    0
+                }
+            })
+            .unwrap_or_default();
+
         // Redraw all progress bars.
-        for bar in 0..self.prog.bars.len() {
+        for bar in start..self.prog.bars.len() {
             self.prog.draw_impl(&Bar(bar), true);
         }
 


### PR DESCRIPTION
Hi, I really enjoy the simplicity of the library
but currently when there are progress bars it's impossible
to print other information because it messes up the bars
and the text gets overwritten. This PR aims to change that.

It adds the `println` function to `Progress` which will
print a message above all progress bars and then redraw
the bars below.

To achieve this I made some internal changes. For one I
unified the code paths for printing cancelled, full, and
in-progress bars by splitting cursor movement into their
own `write!`s. This should not effect performance because
it's all buffered anyway. On that note I switched from
[`LineWriter`][LineWriter] to [`BufWriter`][BufWriter]
because it gives more control on when to flush and
flushing manually only added a single line of code in `bar`.

Most of the drawing was extract from `draw` into the
`draw_impl` function so it can be called from `draw`
and from `println`. I changed `prev` to `prev_percent`
because the last increment before completion is not
always above `1%` but we still want to redraw the bar.
The old version handled this by redrawing the bar every
time it was completed or cancelled, this is no longer
required.

The `println` function accepts a `&str` because only
full lines can be printed with this approach. Sadly
this rules out implementing [`fmt::Write`][Write]
which would have allowed to `write!` to `Progress`.
An alternative approach would have been to add a
function that returns a handle implementing
`fmt::Write` which keeps the progress locked.

For example:
```rust
let p = Progress::new();

{
    let w = p.stderr(); // borrows `mut p`
    write!(w, "Hello ");
    writeln!(w, "World");
}
```

But I deemed the API and implementation too complicated.

I also demonstrate the new feature in the `multi` example by
printing a message when the bar is half full.

[LineWriter]: https://doc.rust-lang.org/stable/std/io/struct.LineWriter.html
[BufWriter]: https://doc.rust-lang.org/stable/std/io/struct.BufWriter.html
[Write]: https://doc.rust-lang.org/stable/std/fmt/trait.Write.html
