### PR TITLE
[feat] allow users to set label and total after Bar's initialization

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -179,8 +179,9 @@ impl Progress {
         self.bars[bar.0].curr = value;
     }
 
-    /// Set a particular [`Bar`]'s total progress value.
-    pub fn set_total(&mut self, bar: &Bar, total: usize) {
+    /// Set a particular [`Bar`]'s progress target value.
+    /// Useful in cases where you don't know the total ahead of time.
+    pub fn set_target(&mut self, bar: &Bar, total: usize) {
         self.bars[bar.0].total = total;
     }
 
@@ -275,10 +276,10 @@ impl Progress {
         self.draw(bar);
     }
 
-    /// Set a particular [`Bar`]'s total progress value and immediately
+    /// Set a particular [`Bar`]'s progress target value and immediately
     /// try to draw it.
-    pub fn set_total_and_draw(&mut self, bar: &Bar, total: usize) {
-        self.set_total(bar, total);
+    pub fn set_target_and_draw(&mut self, bar: &Bar, total: usize) {
+        self.set_target(bar, total);
         self.draw(bar);
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -179,6 +179,16 @@ impl Progress {
         self.bars[bar.0].curr = value;
     }
 
+    /// Set a particular [`Bar`]'s total progress value.
+    pub fn set_total(&mut self, bar: &Bar, total: usize) {
+        self.bars[bar.0].total = total;
+    }
+
+    /// Set a particular [`Bar`]'s label.
+    pub fn set_label<S: Into<String>>(&mut self, bar: &Bar, label: S) {
+        self.bars[bar.0].label = label.into();
+    }
+
     /// Force the drawing of a particular [`Bar`].
     ///
     /// **Note 1:** Drawing will only occur if there is something meaningful to
@@ -262,6 +272,20 @@ impl Progress {
     /// Set a [`Bar`]'s value and immediately try to draw it.
     pub fn set_and_draw(&mut self, bar: &Bar, value: usize) {
         self.set(bar, value);
+        self.draw(bar);
+    }
+
+    /// Set a particular [`Bar`]'s total progress value and immediately
+    /// try to draw it.
+    pub fn set_total_and_draw(&mut self, bar: &Bar, total: usize) {
+        self.set_total(bar, total);
+        self.draw(bar);
+    }
+
+    /// Set a particular [`Bar`]'s label and immediately try to
+    /// draw it.
+    pub fn set_label_and_draw<S: Into<String>>(&mut self, bar: &Bar, label: S) {
+        self.set_label(bar, label);
         self.draw(bar);
     }
 


### PR DESCRIPTION
Hello!

Firstly, thank you for a fantastic crate. I appreciate how simple and easy `Linya` is compared to many other progress bar crates out there.

This PR would add 4 pub set helper functions which would allow the user to modify a specific `Bar`'s total or label after the `Bar` has been initialized. I've found this useful in cases where I do not know the total size of the data, but I want the draw the progress bar and then update its total once gathered. In my local tests I was able to accomplish what I was after.

If there is a more optimal way to achieve this without the need for this PR, please let me know.

Thanks,
ciehanski